### PR TITLE
Introduce Makefile to update examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+all: examples/sequential.png examples/diverging.png examples/qualitative.png
+
+examples/sequential.png: examples/sequential.plt $(wildcard sequential/*.plt)
+	(cd examples && gnuplot $(notdir $<))
+
+examples/diverging.png: examples/diverging.plt $(wildcard diverging/*.plt)
+	(cd examples && gnuplot $(notdir $<))
+
+examples/qualitative.png: examples/qualitative.plt $(wildcard qualitative/*.plt)
+	(cd examples && gnuplot $(notdir $<))


### PR DESCRIPTION
Repetition is used because a pattern matching rule won't work. The
gnuplot scripts in examples/ depend on palettes in each of
sequential/diverging/qualitative directories, this dependency can't be
expressed as a single pattern-matching rule e.g. like

`examples/%.png : examples/%.plt $(wildcard %/*.plt)`